### PR TITLE
Add dev container config and update go to 1.26

### DIFF
--- a/.devcontainer/devcontainer.jsonc
+++ b/.devcontainer/devcontainer.jsonc
@@ -1,0 +1,17 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go .
+{
+	"name": "Go",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/go:2-1.26-trixie",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "apt update && apt install -y pre-commit && pre-commit install",
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS
+.DS_Store
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module pathlength
 
-go 1.25.4
+go 1.26


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Go development container environment with automated setup including pre-commit hooks
  * Updated Go toolchain requirement to version 1.26
  * Enhanced repository configuration to exclude macOS metadata files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->