### PR TITLE
fix(model): fix ray tracing calculations, blur circle mapping, and resolution interpolation

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -118,7 +118,6 @@ func (m *Model) calculateRessens() {
 						yy = rhabdoms[i+1]
 					}
 					opticAxis = m.OmmatidialAngle * float64(i)
-					break
 				}
 			}
 			diff := xz - yy

--- a/model.go
+++ b/model.go
@@ -106,165 +106,165 @@ func (m *Model) runModel() {
 	debugWriter := bufio.NewWriter(debugFile)
 	defer debugWriter.Flush()
 
-	// Reset pigments
-	m.ShieldingPigment = 0.0
-	m.TapetalPigment = 0.0
 	incrementAmount := p.RhabdomLength / 10.0
 
-	// Main loop structure from Python version
-	for {
-		fmt.Printf("P: %.2f, T: %.2f\n", m.ShieldingPigment, m.TapetalPigment)
-		fmt.Fprintf(pathlengthsWriter, "%.6f\n%.6f\n", m.ShieldingPigment, m.TapetalPigment)
-		fmt.Fprintf(debugWriter, "P: %.2f, T: %.2f\n", m.ShieldingPigment, m.TapetalPigment)
+	// Main pigment loops (11 steps for Shielding pigment, 11 steps for Tapetal pigment)
+	for pStep := 0; pStep <= 10; pStep++ {
+		m.ShieldingPigment = float64(pStep) * incrementAmount
+		for tStep := 0; tStep <= 10; tStep++ {
+			m.TapetalPigment = float64(tStep) * incrementAmount
 
-		// Reset for this pigment run
-		m.IncidenceOmmatidialAngle = 0.0
-		m.RefractedOmmatidialAngle = 0.0
-		currentFacet := 0
+			fmt.Printf("P: %.2f, T: %.2f\n", m.ShieldingPigment, m.TapetalPigment)
+			fmt.Fprintf(pathlengthsWriter, "%.6f\n%.6f\n", m.ShieldingPigment, m.TapetalPigment)
+			fmt.Fprintf(debugWriter, "P: %.2f, T: %.2f\n", m.ShieldingPigment, m.TapetalPigment)
 
-		// Loop over each facet
-		for currentFacet < m.NumberOfFacets {
-			var rowData []string
+			// Loop over each facet across the eyeshine patch axis
+			for currentFacet := 0; currentFacet < m.NumberOfFacets; currentFacet++ {
+				m.IncidenceOmmatidialAngle = float64(currentFacet) * m.OmmatidialAngle
 
-			// Account for refraction at the cornea
-			switch {
-			case m.IncidenceOmmatidialAngle > 0 && m.IncidenceOmmatidialAngle <= 15:
-				m.RefractedOmmatidialAngle = (m.IncidenceOmmatidialAngle * 0.9494) + 0.004667
-			case m.IncidenceOmmatidialAngle > 15 && m.IncidenceOmmatidialAngle <= 35:
-				m.RefractedOmmatidialAngle = (m.IncidenceOmmatidialAngle * 0.9407) + 0.1648
-			case m.IncidenceOmmatidialAngle > 35 && m.IncidenceOmmatidialAngle <= 50:
-				m.RefractedOmmatidialAngle = (m.IncidenceOmmatidialAngle * 0.9196) + 0.8676
-			case m.IncidenceOmmatidialAngle > 50 && m.IncidenceOmmatidialAngle <= 60:
-				m.RefractedOmmatidialAngle = (m.IncidenceOmmatidialAngle * 0.8677) + 3.38
-			case m.IncidenceOmmatidialAngle > 60:
-				fmt.Println("UNREAL ANGLE AT CORNEA")
-				rowData = append(rowData, "UNREAL ANGLE AT CORNEA")
-			}
+				// Account for refraction at the cornea
+				switch {
+				case m.IncidenceOmmatidialAngle == 0:
+					m.RefractedOmmatidialAngle = 0.0
+				case m.IncidenceOmmatidialAngle > 0 && m.IncidenceOmmatidialAngle <= 15:
+					m.RefractedOmmatidialAngle = (m.IncidenceOmmatidialAngle * 0.9494) + 0.004667
+				case m.IncidenceOmmatidialAngle > 15 && m.IncidenceOmmatidialAngle <= 35:
+					m.RefractedOmmatidialAngle = (m.IncidenceOmmatidialAngle * 0.9407) + 0.1648
+				case m.IncidenceOmmatidialAngle > 35 && m.IncidenceOmmatidialAngle <= 50:
+					m.RefractedOmmatidialAngle = (m.IncidenceOmmatidialAngle * 0.9196) + 0.8676
+				case m.IncidenceOmmatidialAngle > 50 && m.IncidenceOmmatidialAngle <= 60:
+					m.RefractedOmmatidialAngle = (m.IncidenceOmmatidialAngle * 0.8677) + 3.38
+				case m.IncidenceOmmatidialAngle > 60:
+					fmt.Println("UNREAL ANGLE AT CORNEA")
+					m.RefractedOmmatidialAngle = 60.0
+				}
 
-			// Light loss at cone due to angle of incidence
-			var facetNum float64
-			if m.RefractedOmmatidialAngle == 0 {
-				facetNum = 1.0
-			} else {
-				cc := p.FacetWidth / math.Abs(math.Tan(m.RefractedOmmatidialAngle*degToRadConv))
-				var fw float64
-				if cc > p.FacetWidth*2.0 {
-					fw = math.Cos(m.IncidenceOmmatidialAngle*degToRadConv) * p.FacetWidth
+				// Light loss at cone due to angle of incidence
+				var facetNum float64
+				if m.RefractedOmmatidialAngle == 0 {
+					facetNum = 1.0
 				} else {
-					ll := (2.0 * cc) - (2.0 * p.FacetWidth)
-					fw = math.Sin(m.IncidenceOmmatidialAngle*degToRadConv) * ll
+					cc := p.FacetWidth / math.Abs(math.Tan(m.RefractedOmmatidialAngle*degToRadConv))
+					var fw float64
+					if cc > p.FacetWidth*2.0 {
+						fw = math.Cos(m.IncidenceOmmatidialAngle*degToRadConv) * p.FacetWidth
+					} else {
+						ll := (2.0 * cc) - (2.0 * p.FacetWidth)
+						fw = math.Sin(m.IncidenceOmmatidialAngle*degToRadConv) * ll
+					}
+					facetNum = fw / p.FacetWidth
 				}
-				facetNum = fw / p.FacetWidth
-			}
-			if facetNum > 1.0 {
-				facetNum = 1.0
-			}
-
-			// --- Path Calculation Logic from Python ---
-			rhabdomLength := m.OldRhabdomLength // Use a local copy for calculations
-
-			if m.IncidenceOmmatidialAngle == 0 {
-				// CASE 4: Perpendicular ray
-				var val float64
-				if m.TapetalPigment == 0 || m.ShieldingPigment > 0 {
-					val = rhabdomLength * facetNum
-				} else {
-					val = (rhabdomLength * 2.0) * facetNum
+				if facetNum > 1.0 {
+					facetNum = 1.0
 				}
-				rowData = append(rowData, fmt.Sprintf("%.6f", val))
-			} else {
-				y := m.RhabdomRadius / math.Abs(math.Tan(m.RefractedOmmatidialAngle*degToRadConv))
-
-				if y >= rhabdomLength {
-					// CASE 3: Bounce off base
-					var x, v, val float64
-					mx := math.Sqrt(math.Pow(rhabdomLength, 2) + math.Pow(m.RhabdomRadius, 2))
-					if y == rhabdomLength {
-						x = mx
-					} else {
-						x = rhabdomLength / math.Abs(math.Cos(m.RefractedOmmatidialAngle*degToRadConv))
-					}
-					if x > m.OldRhabdomLength {
-						v = x
-					} else {
-						v = m.OldRhabdomLength
-					}
-
-					if m.TapetalPigment == 0 || m.ShieldingPigment > 0 {
-						val = x * facetNum
-					} else {
-						val = (x + v) * facetNum
-					}
-					rowData = append(rowData, fmt.Sprintf("%.6f", val))
-				} else if y > (rhabdomLength-m.ShieldingPigment) || y > (rhabdomLength-m.TapetalPigment) || m.RefractedOmmatidialAngle < m.CriticalAngle {
-					// CASE 2: Reflection from edge
-					var val float64
-					x := m.RhabdomRadius / math.Abs(math.Sin(m.RefractedOmmatidialAngle*degToRadConv))
-					z := (rhabdomLength - y) / math.Abs(math.Cos(m.RefractedOmmatidialAngle*degToRadConv))
-					if z > x {
-						z = x
-					}
-					var v float64
-					if (x + z) > m.OldRhabdomLength {
-						v = x + z
-					} else {
-						v = m.OldRhabdomLength
-					}
-					if m.TapetalPigment == 0 {
-						val = (x + z) * facetNum
-					} else {
-						val = (x + z + v) * facetNum
-					}
-					if m.ShieldingPigment > 0 {
-						val = (x + z) * facetNum
-					}
-					if m.ShieldingPigment > (rhabdomLength - y) {
-						val = x * facetNum
-					}
-					rowData = append(rowData, fmt.Sprintf("%.6f", val))
-				} else {
-					// CASE 1: No reflection
-					boa := m.RefractedOmmatidialAngle
-					// This case in python seems to be a loop, here we simulate one pass
-					x := m.RhabdomRadius / math.Abs(math.Sin(boa*degToRadConv))
-					rowData = append(rowData, fmt.Sprintf("%.6f", x*facetNum))
-					// The python version modifies state and continues the loop, which is complex.
-					// This translation simulates the first pass, which is the dominant effect.
+				if facetNum < 0.0 {
+					facetNum = 0.0
 				}
-			}
 
-			// Increment for next facet
-			currentFacet++
-			m.IncidenceOmmatidialAngle += m.OmmatidialAngle
-
-			// Account for blur circle
-			if p.BlurCircleExtent > 0 {
-				fd := float64(m.NumberOfFacets) / p.BlurCircleExtent
-				nx := 0
-				for i := 0; i < int(p.BlurCircleExtent); i++ {
-					nx++
-					if float64(currentFacet) > (fd * float64(nx)) {
-						m.RefractedOmmatidialAngle += m.OmmatidialAngle
-						rowData = append(rowData, "0")
+				// Leading zeros for blur circle off-axis shift and angle adjustment
+				var rowData []string
+				boa := m.RefractedOmmatidialAngle
+				if p.BlurCircleExtent > 0 {
+					fd := float64(m.NumberOfFacets) / p.BlurCircleExtent
+					for i := 1; i <= int(p.BlurCircleExtent); i++ {
+						if float64(currentFacet) > (fd * float64(i)) {
+							boa += m.OmmatidialAngle
+							rowData = append(rowData, "0")
+						}
 					}
 				}
+
+				// Ray tracing through rhabdom array
+				rhabdomLength := m.OldRhabdomLength
+				cz := 0
+				for {
+					// Account for tapered/pointy rhabdom shape at proximal entrance
+					if boa > m.CriticalAngle && cz == 0 {
+						boa -= p.ProximalRhabdomAngle
+					}
+
+					if m.IncidenceOmmatidialAngle == 0 {
+						// CASE 4: Perpendicular ray
+						var val float64
+						if m.TapetalPigment == 0 || m.ShieldingPigment > 0 {
+							val = rhabdomLength * facetNum
+						} else {
+							val = (rhabdomLength * 2.0) * facetNum
+						}
+						rowData = append(rowData, fmt.Sprintf("%.6f", val))
+						break
+					}
+
+					y := m.RhabdomRadius / math.Abs(math.Tan(boa*degToRadConv))
+
+					if y >= rhabdomLength {
+						// CASE 3: Bounce off base
+						var x, v, val float64
+						mx := math.Sqrt(math.Pow(rhabdomLength, 2) + math.Pow(m.RhabdomRadius, 2))
+						if y == rhabdomLength {
+							x = mx
+						} else {
+							x = rhabdomLength / math.Abs(math.Cos(boa*degToRadConv))
+						}
+						if x > m.OldRhabdomLength {
+							v = x
+						} else {
+							v = m.OldRhabdomLength
+						}
+
+						if m.TapetalPigment == 0 || m.ShieldingPigment > 0 {
+							val = x * facetNum
+						} else {
+							val = (x + v) * facetNum
+						}
+						rowData = append(rowData, fmt.Sprintf("%.6f", val))
+						break
+					} else if y > (rhabdomLength-m.ShieldingPigment) || y > (rhabdomLength-m.TapetalPigment) || boa < m.CriticalAngle {
+						// CASE 2: Reflection from edge
+						var val float64
+						x := m.RhabdomRadius / math.Abs(math.Sin(boa*degToRadConv))
+						z := (rhabdomLength - y) / math.Abs(math.Cos(boa*degToRadConv))
+						if z > x {
+							z = x
+						}
+						var v float64
+						if (x + z) > m.OldRhabdomLength {
+							v = x + z
+						} else {
+							v = m.OldRhabdomLength
+						}
+						if m.TapetalPigment == 0 {
+							val = (x + z) * facetNum
+						} else {
+							val = (x + z + v) * facetNum
+						}
+						if m.ShieldingPigment > 0 {
+							val = (x + z) * facetNum
+						}
+						if m.ShieldingPigment > (rhabdomLength - y) {
+							val = x * facetNum
+						}
+						rowData = append(rowData, fmt.Sprintf("%.6f", val))
+						break
+					} else {
+						// CASE 1: No reflection (ray passes through rhabdom wall into adjacent rhabdom)
+						x := m.RhabdomRadius / math.Abs(math.Sin(boa*degToRadConv))
+						rowData = append(rowData, fmt.Sprintf("%.6f", x*facetNum))
+						rhabdomLength -= y
+						boa += m.OmmatidialAngle
+						cz = 1
+						if rhabdomLength <= m.TapetalPigment || rhabdomLength <= m.ShieldingPigment {
+							break
+						}
+					}
+				}
+
+				// Finish row
+				rowData = append(rowData, "998")
+				fmt.Fprintln(pathlengthsWriter, strings.Join(rowData, ","))
 			}
 
-			// Finish row
-			rowData = append(rowData, "998")
-			fmt.Fprintln(pathlengthsWriter, strings.Join(rowData, ","))
-		}
-
-		fmt.Fprintln(pathlengthsWriter, "999")
-
-		// Pigment increment logic from python
-		if m.TapetalPigment >= m.OldRhabdomLength && m.ShieldingPigment >= m.OldRhabdomLength {
-			break // End simulation
-		} else if m.TapetalPigment >= m.OldRhabdomLength {
-			m.TapetalPigment = 0.0
-			m.ShieldingPigment += incrementAmount
-		} else {
-			m.TapetalPigment += incrementAmount
+			fmt.Fprintln(pathlengthsWriter, "999")
 		}
 	}
 }

--- a/model_test.go
+++ b/model_test.go
@@ -1,0 +1,200 @@
+// FILE: model_test.go
+// This file contains tests for the model initialization and simulation logic.
+
+package main
+
+import (
+	"bufio"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestInitialCalculations(t *testing.T) {
+	params := Parameters{
+		SpeciesName:              "test_eye",
+		RhabdomLength:            180,
+		RhabdomWidth:             25,
+		EyeDiameter:              7800,
+		FacetWidth:               50,
+		ApertureDiameter:         3200,
+		CytoplasmRefractiveIndex: 1.34,
+		RhabdomRefractiveIndex:   1.37,
+		BlurCircleExtent:         18,
+		ProximalRhabdomAngle:     12.5,
+	}
+
+	model := NewModel(params)
+
+	expectedCircumference := math.Pi * 7800.0
+	if math.Abs(model.CircumferenceOfEye-expectedCircumference) > 1e-6 {
+		t.Errorf("Expected CircumferenceOfEye %f, got %f", expectedCircumference, model.CircumferenceOfEye)
+	}
+
+	expectedOmmatidialAngle := (50.0 / expectedCircumference) * 360.0
+	if math.Abs(model.OmmatidialAngle-expectedOmmatidialAngle) > 1e-6 {
+		t.Errorf("Expected OmmatidialAngle %f, got %f", expectedOmmatidialAngle, model.OmmatidialAngle)
+	}
+
+	// Snell's law critical angle
+	expectedSnell := math.Asin(1.34/1.37) / (math.Pi / 180.0)
+	expectedCritical := 90.0 - expectedSnell
+	if math.Abs(model.CriticalAngle-expectedCritical) > 1e-6 {
+		t.Errorf("Expected CriticalAngle %f, got %f", expectedCritical, model.CriticalAngle)
+	}
+
+	if model.NumberOfFacets <= 0 {
+		t.Errorf("Expected NumberOfFacets > 0, got %d", model.NumberOfFacets)
+	}
+}
+
+func TestRunModelBlurCircleAndPointyRhabdom(t *testing.T) {
+	// Compare flat lateral vs pointy lateral simulations
+	paramsFlat := Parameters{
+		SpeciesName:              "test_flat",
+		RhabdomLength:            180,
+		RhabdomWidth:             25,
+		EyeDiameter:              7800,
+		FacetWidth:               50,
+		ApertureDiameter:         3200,
+		CytoplasmRefractiveIndex: 1.34,
+		RhabdomRefractiveIndex:   1.37,
+		BlurCircleExtent:         18,
+		ProximalRhabdomAngle:     0,
+	}
+
+	paramsPointy := Parameters{
+		SpeciesName:              "test_pointy",
+		RhabdomLength:            180,
+		RhabdomWidth:             25,
+		EyeDiameter:              7800,
+		FacetWidth:               50,
+		ApertureDiameter:         3200,
+		CytoplasmRefractiveIndex: 1.34,
+		RhabdomRefractiveIndex:   1.37,
+		BlurCircleExtent:         18,
+		ProximalRhabdomAngle:     12.5,
+	}
+
+	modelFlat := NewModel(paramsFlat)
+	modelPointy := NewModel(paramsPointy)
+
+	modelFlat.runModel()
+	modelPointy.runModel()
+
+	defer os.Remove("test_flat_pathlengths.csv")
+	defer os.Remove("test_flat_debug.csv")
+	defer os.Remove("test_pointy_pathlengths.csv")
+	defer os.Remove("test_pointy_debug.csv")
+
+	// Read flat pathlengths file
+	fileFlat, err := os.Open("test_flat_pathlengths.csv")
+	if err != nil {
+		t.Fatalf("Failed to open flat pathlengths file: %v", err)
+	}
+	defer fileFlat.Close()
+
+	var linesFlat []string
+	scanner := bufio.NewScanner(fileFlat)
+	for scanner.Scan() {
+		linesFlat = append(linesFlat, scanner.Text())
+	}
+
+	// Verify leading zeros exist for off-axis blur circle facets
+	foundLeadingZero := false
+	blockCount := 0
+	for _, line := range linesFlat {
+		if line == "999" {
+			blockCount++
+		}
+		if strings.Contains(line, "998") && strings.HasPrefix(line, "0,") {
+			foundLeadingZero = true
+		}
+	}
+
+	if !foundLeadingZero {
+		t.Errorf("Expected leading zeros in blur circle facets, but none found")
+	}
+
+	if blockCount != 121 {
+		t.Errorf("Expected 121 pigment blocks (11x11), got %d", blockCount)
+	}
+
+	// Read pointy pathlengths file and verify difference due to ProximalRhabdomAngle
+	filePointy, err := os.Open("test_pointy_pathlengths.csv")
+	if err != nil {
+		t.Fatalf("Failed to open pointy pathlengths file: %v", err)
+	}
+	defer filePointy.Close()
+
+	var linesPointy []string
+	scannerPointy := bufio.NewScanner(filePointy)
+	for scannerPointy.Scan() {
+		linesPointy = append(linesPointy, scannerPointy.Text())
+	}
+
+	hasDifference := false
+	for i := 0; i < len(linesFlat) && i < len(linesPointy); i++ {
+		if linesFlat[i] != linesPointy[i] {
+			hasDifference = true
+			break
+		}
+	}
+
+	if !hasDifference {
+		t.Errorf("Expected differences between flat and pointy rhabdom simulations, but got identical results")
+	}
+}
+
+func TestCalculateRessensFullMatrix(t *testing.T) {
+	params := Parameters{
+		SpeciesName:              "test_matrix",
+		RhabdomLength:            127,
+		RhabdomWidth:             15.8,
+		EyeDiameter:              2480,
+		FacetWidth:               22.5,
+		ApertureDiameter:         870,
+		CytoplasmRefractiveIndex: 1.34,
+		RhabdomRefractiveIndex:   1.37,
+		BlurCircleExtent:         1,
+		ProximalRhabdomAngle:     0,
+	}
+
+	model := NewModel(params)
+	model.runModel()
+	model.calculateRessens()
+
+	defer os.Remove("test_matrix_pathlengths.csv")
+	defer os.Remove("test_matrix_debug.csv")
+	defer os.Remove("test_matrix_summary_res.csv")
+	defer os.Remove("test_matrix_summary_sen.csv")
+
+	// Verify resolution file has 11 lines of 11 comma-separated values
+	resBytes, err := os.ReadFile("test_matrix_summary_res.csv")
+	if err != nil {
+		t.Fatalf("Failed to read resolution summary file: %v", err)
+	}
+
+	resLines := strings.Split(strings.TrimSpace(string(resBytes)), "\n")
+	if len(resLines) != 11 {
+		t.Errorf("Expected 11 rows in summary resolution file, got %d", len(resLines))
+	}
+
+	for rowIdx, line := range resLines {
+		parts := strings.Split(line, ",")
+		if len(parts) != 11 {
+			t.Errorf("Row %d: expected 11 columns, got %d", rowIdx, len(parts))
+		}
+		for colIdx, valStr := range parts {
+			val, err := strconv.Atoi(strings.TrimSpace(valStr))
+			if err != nil {
+				t.Errorf("Row %d, Col %d: invalid integer value '%s'", rowIdx, colIdx, valStr)
+			}
+			if val <= 0 {
+				t.Errorf("Row %d, Col %d: expected positive resolution value, got %d", rowIdx, colIdx, val)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary of Changes

This PR fixes several ray tracing simulation calculations and resolution post-processing issues in the Go implementation:

1. **Blur Circle Leading Zeros Mapping (`model.go`):**
   - Corrected blur circle off-axis shifts to prepend `"0"` entries to `rowData` before calculating pathlengths so that light from peripheral facets correctly registers in off-axis rhabdoms (rhabdom 1, 2, 3, etc.) rather than being erroneously assigned to the axial rhabdom (rhabdom 0).

2. **Pointy Rhabdom Acceptance Angle (`model.go`):**
   - Applied `ProximalRhabdomAngle` (`boa -= ProximalRhabdomAngle` when `boa > CriticalAngle && cz == 0`) so that simulations for pointy-ended rhabdoms (such as *Nephrops norvegicus* lateral and anterior eyes) properly model enhanced acceptance of oblique rays and total internal reflection.

3. **Multi-Rhabdom Ray Propagation for Case 1 (`model.go`):**
   - Restored full ray tracing loop for rays exceeding critical angle (Case 1) so that rays continue propagating across adjacent rhabdoms at depth $y$ (`rhabdomLength -= y`, `boa += OmmatidialAngle`, `cz = 1`) until reflecting from the base, reflecting from an edge, or being absorbed by pigment.

4. **Cornea Refraction Angle Calculation (`model.go`):**
   - Refactored cornea refraction angle $\theta_{refr}$ and cone transmission factor `facetNum` calculation so that blur circle off-axis angle increments are preserved during ray tracing.

5. **Deterministic Pigment Loops (`model.go`):**
   - Replaced floating-point increment comparisons with integer step iterations (`0..10` for shielding and tapetal pigments) to prevent IEEE 754 precision issues from generating unintended 12th pigment steps.

6. **FWHM Angular Resolution Search (`csv.go`):**
   - Removed premature `break` in `calculateRessens` so the scan finds the actual 50% half-maximum threshold crossing point and correctly interpolates the acceptance angle.

7. **Unit Test Suite (`model_test.go`):**
   - Added unit tests covering initialization derived parameters, blur circle column structure, pointy vs. flat rhabdom differentiation, and full 11×11 summary matrix verification.

## Testing
- `go test -v ./...` passed with all pre-commit hooks.
- Verified simulations against example datasets (`nephrops`, `acanthephyra`, `astacodes`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved optical-axis calculations by evaluating all relevant rhabdom values.
  * Improved simulation accuracy across shielding, tapetal pigment, refraction, transmission, and ray-tracing scenarios.
  * Corrected blur-circle output formatting, including leading zeros.
  * Ensured generated result matrices and pigment combinations are processed consistently.

* **Tests**
  * Added comprehensive validation for model calculations, simulation outputs, CSV cleanup, formatting, and full-resolution result generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->