### PR TITLE
feat(cli): make debug output optional and standardize pathlength csv

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ refactor(model): simplify ray tracing calculation logic
 The codebase is organized into Go files in a single package:
 
 1. **pathlength.go** - Entry point with CLI argument parsing
-   - Handles flags: `-f` (file), `-h` (help), `-v` (version), `-c` (citation), `-l` (license)
+   - Handles flags: `-f` (file), `-d` (debug), `-h` (help), `-v` (version), `-c` (citation), `-l` (license)
    - Parses parameter file and orchestrates simulation runs
    - Main loop iterates over each parameter set from CSV input
 
@@ -125,7 +125,7 @@ The codebase is organized into Go files in a single package:
      - For each combination, iterates over facets in the eyeshine patch
      - Calculates light paths through rhabdoms based on angle of incidence
      - Four main cases: perpendicular ray, no reflection, edge reflection, base bounce
-     - Outputs pathlengths to CSV file
+     - Outputs pathlengths to CSV file (and optional debug file when `-d` is passed)
 
 3. **csv.go** - File I/O and data processing
    - `parseInputParameters()`: Reads CSV parameter file, returns slice of Parameters
@@ -139,13 +139,14 @@ The codebase is organized into Go files in a single package:
    - `TestCalculateRessens`: Tests resolution/sensitivity calculation
    - `TestInitialCalculations`: Tests derived optical calculations
    - `TestRunModelBlurCircleAndPointyRhabdom`: Tests blur circle shifts and pointy rhabdom behavior
+   - `TestDebugFlagOutput`: Tests optional debug CSV file generation
    - `TestCalculateRessensFullMatrix`: Tests resolution and sensitivity matrix generation
 
 ### Data Flow
 
 1. CSV parameter file → `parseInputParameters()` → slice of `Parameters`
 2. For each Parameters → `NewModel()` → `Model` with calculated values
-3. `Model.runModel()` → writes `{species}_pathlengths.csv` and `{species}_debug.csv`
+3. `Model.runModel()` → writes `{species}_pathlengths.csv` (and `{species}_debug.csv` if `-d` is set)
 4. `Model.calculateRessens()` → reads pathlengths → writes summary CSV files
 
 ### Input File Format
@@ -162,10 +163,10 @@ Each row represents a separate simulation run. Multiple rows can be processed in
 ### Output Files
 
 For each parameter set with species name "X", generates:
-- `X_debug.csv` - Debug information from simulation
 - `X_pathlengths.csv` - Raw pathlength data for each facet/pigment combination
 - `X_summary_res.csv` - Calculated resolution values
 - `X_summary_sen.csv` - Calculated sensitivity values
+- `X_debug.csv` - (Optional, generated with `-d`) Debug information from simulation
 
 ## Key Implementation Notes
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ go run .
 Outputs:
 
 ```bash
-Usage: pathlength -f filename [-h] [-v]
+Usage: pathlength -f filename [-c] [-d] [-h] [-l] [-v]
   -c    Show the program citation.
+  -d    Generate debug CSV output file.
   -f string
         Path to a parameter file (CSV format). (Required)
   -h    Show this help message.
@@ -121,6 +122,8 @@ INFO: Calculating resolution and sensitivity...
 --- PASS: TestInitialCalculations (0.00s)
 === RUN   TestRunModelBlurCircleAndPointyRhabdom
 --- PASS: TestRunModelBlurCircleAndPointyRhabdom (0.01s)
+=== RUN   TestDebugFlagOutput
+--- PASS: TestDebugFlagOutput (0.00s)
 === RUN   TestCalculateRessensFullMatrix
 INFO: Calculating resolution and sensitivity...
 --- PASS: TestCalculateRessensFullMatrix (0.00s)
@@ -145,8 +148,9 @@ chmod +x pathlength
 Outputs:
 
 ```bash
-Usage: pathlength -f filename [-h] [-v]
+Usage: pathlength -f filename [-c] [-d] [-h] [-l] [-v]
   -c    Show the program citation.
+  -d    Generate debug CSV output file.
   -f string
         Path to a parameter file (CSV format). (Required)
   -h    Show this help message.
@@ -258,6 +262,14 @@ INFO: Calculating resolution and sensitivity...
 All simulations complete.
 ```
 
+### Run with debug output
+
+To generate optional `{species}_debug.csv` files containing simulation debug logs (e.g. pigment migration steps):
+
+```bash
+./pathlength -f example_data/acanthephyra_parameters.txt -d
+```
+
 ## Required parameters
 
 A CSV format file is required as input to the program. You can provide multiple lines for separate runs of the model. The format should be as follows:
@@ -288,18 +300,18 @@ genus	= A prefix for the output filenames e.g. organism genus name (lowercase al
 
 ## Output files
 
-Four output files are created:
+The following output files are created:
 
-* genus_debug.csv
-* genus_pathlengths.csv
-* genus_summary_res.csv
-* genus_summary_sen.csv
+* `genus_pathlengths.csv` - Raw pathlength data for each facet/pigment combination
+* `genus_summary_res.csv` - Calculated resolution summary
+* `genus_summary_sen.csv` - Calculated sensitivity summary
+* `genus_debug.csv` - (Optional) Debug information from simulation, enabled with `-d`
 
 The pathlengths file contains multiple rows for each facet with the various combinations of tapetal and shielding pigment lengths in the adjacent columns and then multiple columns with the pathlengths.
 
-The resolution file contains the calculated resolution values.
+The summary resolution file contains the calculated resolution values.
 
-The sensitivity file contains the calculated sensitivity values.
+The summary sensitivity file contains the calculated sensitivity values.
 
 ## Citation
 

--- a/csv.go
+++ b/csv.go
@@ -52,6 +52,7 @@ func (m *Model) calculateRessens() {
 	facet := 0.0
 	arem := 0.0
 	cc, dd := 0, 0
+	headerCount := 0
 
 	scanner := bufio.NewScanner(pathlengthsFile)
 	for scanner.Scan() {
@@ -60,48 +61,7 @@ func (m *Model) calculateRessens() {
 			continue
 		}
 
-		if strings.Contains(line, "998") {
-			parts := strings.Split(line, ",")
-			rhabdom := 0
-			tot := 0.0
-			area := math.Pi * math.Pow(facet+0.5, 2)
-			inci := math.Pi * math.Pow(facet-0.5, 2)
-			if facet == 0 {
-				inci = 0
-			}
-			torus := area - inci
-			if area > arem {
-				arem = area
-			}
-
-			for _, part := range parts {
-				if part == "998" {
-					break
-				}
-				pathlength, _ := strconv.ParseFloat(part, 64)
-				var absorbance, bx float64
-				if pathlength > 0 {
-					absorbance = 1 - math.Exp(-0.01*pathlength)
-				} else {
-					absorbance = 0
-				}
-				if rhabdom == 0 && absorbance > 0 {
-					bx = 100 * absorbance
-				} else if rhabdom > 0 && absorbance > 0 {
-					bx = 100 * ((1 - tot) * absorbance)
-				}
-				if absorbance == 0 {
-					bx = 0
-				}
-				tot += bx / 100.0
-				bx *= torus
-				if rhabdom < len(rhabdoms) {
-					rhabdoms[rhabdom] += bx
-				}
-				rhabdom++
-			}
-			facet++
-		} else if line == "999" {
+		if line == "999" {
 			// End of block, summarize
 			sens := 0.0
 			for _, r := range rhabdoms {
@@ -138,7 +98,7 @@ func (m *Model) calculateRessens() {
 			} else {
 				matrixSens = append(matrixSens, "0")
 			}
-			matrixRes = append(matrixRes, fmt.Sprintf("%d", int(res*200)))
+			matrixRes = append(matrixRes, fmt.Sprintf("%d", int(res*200.0)))
 
 			cc++
 			if cc == 11 {
@@ -146,10 +106,51 @@ func (m *Model) calculateRessens() {
 				cc = 0
 			}
 			// Reset for next block
-			for i := range rhabdoms {
-				rhabdoms[i] = 0
-			}
+			rhabdoms = make([]float64, 21)
 			facet = 0
+			headerCount = 0
+		} else if headerCount < 2 {
+			// Shielding or Tapetal pigment header line
+			headerCount++
+		} else {
+			// Facet pathlength row
+			parts := strings.Split(line, ",")
+			rhabdom := 0
+			tot := 0.0
+			area := math.Pi * math.Pow(facet+0.5, 2)
+			inci := math.Pi * math.Pow(facet-0.5, 2)
+			if facet == 0 {
+				inci = 0
+			}
+			torus := area - inci
+			if area > arem {
+				arem = area
+			}
+
+			for _, part := range parts {
+				pathlength, _ := strconv.ParseFloat(part, 64)
+				var absorbance, bx float64
+				if pathlength > 0 {
+					absorbance = 1 - math.Exp(-0.01*pathlength)
+				} else {
+					absorbance = 0
+				}
+				if rhabdom == 0 && absorbance > 0 {
+					bx = 100 * absorbance
+				} else if rhabdom > 0 && absorbance > 0 {
+					bx = 100 * ((1 - tot) * absorbance)
+				}
+				if absorbance == 0 {
+					bx = 0
+				}
+				tot += bx / 100.0
+				bx *= torus
+				if rhabdom < len(rhabdoms) {
+					rhabdoms[rhabdom] += bx
+				}
+				rhabdom++
+			}
+			facet++
 		}
 	}
 	// Write the final line of data

--- a/csv_test.go
+++ b/csv_test.go
@@ -107,7 +107,7 @@ func TestCalculateRessens(t *testing.T) {
 	// Create a mock pathlengths file
 	pathlengthsContent := `0.000000
 0.000000
-84.000000,998
+84.000000
 999
 `
 	pathlengthsFileName := fmt.Sprintf("%s_pathlengths.csv", params.SpeciesName)

--- a/model.go
+++ b/model.go
@@ -45,6 +45,7 @@ type Model struct {
 	RefractedOmmatidialAngle float64
 	RhabdomAlphaAngle        float64
 	OldRhabdomLength         float64 // Store original length
+	DebugMode                bool
 }
 
 var degToRadConv = math.Pi / 180.0
@@ -98,13 +99,16 @@ func (m *Model) runModel() {
 	pathlengthsWriter := bufio.NewWriter(pathlengthsFile)
 	defer pathlengthsWriter.Flush()
 
-	debugFile, err := os.Create(fmt.Sprintf("%s_debug.csv", p.SpeciesName))
-	if err != nil {
-		log.Fatalf("Error creating debug file: %v", err)
+	var debugWriter *bufio.Writer
+	if m.DebugMode {
+		debugFile, err := os.Create(fmt.Sprintf("%s_debug.csv", p.SpeciesName))
+		if err != nil {
+			log.Fatalf("Error creating debug file: %v", err)
+		}
+		defer debugFile.Close()
+		debugWriter = bufio.NewWriter(debugFile)
+		defer debugWriter.Flush()
 	}
-	defer debugFile.Close()
-	debugWriter := bufio.NewWriter(debugFile)
-	defer debugWriter.Flush()
 
 	incrementAmount := p.RhabdomLength / 10.0
 
@@ -116,7 +120,9 @@ func (m *Model) runModel() {
 
 			fmt.Printf("P: %.2f, T: %.2f\n", m.ShieldingPigment, m.TapetalPigment)
 			fmt.Fprintf(pathlengthsWriter, "%.6f\n%.6f\n", m.ShieldingPigment, m.TapetalPigment)
-			fmt.Fprintf(debugWriter, "P: %.2f, T: %.2f\n", m.ShieldingPigment, m.TapetalPigment)
+			if debugWriter != nil {
+				fmt.Fprintf(debugWriter, "P: %.2f, T: %.2f\n", m.ShieldingPigment, m.TapetalPigment)
+			}
 
 			// Loop over each facet across the eyeshine patch axis
 			for currentFacet := 0; currentFacet < m.NumberOfFacets; currentFacet++ {
@@ -259,8 +265,7 @@ func (m *Model) runModel() {
 					}
 				}
 
-				// Finish row
-				rowData = append(rowData, "998")
+				// Write row
 				fmt.Fprintln(pathlengthsWriter, strings.Join(rowData, ","))
 			}
 

--- a/model_test.go
+++ b/model_test.go
@@ -85,9 +85,7 @@ func TestRunModelBlurCircleAndPointyRhabdom(t *testing.T) {
 	modelPointy.runModel()
 
 	defer os.Remove("test_flat_pathlengths.csv")
-	defer os.Remove("test_flat_debug.csv")
 	defer os.Remove("test_pointy_pathlengths.csv")
-	defer os.Remove("test_pointy_debug.csv")
 
 	// Read flat pathlengths file
 	fileFlat, err := os.Open("test_flat_pathlengths.csv")
@@ -109,7 +107,7 @@ func TestRunModelBlurCircleAndPointyRhabdom(t *testing.T) {
 		if line == "999" {
 			blockCount++
 		}
-		if strings.Contains(line, "998") && strings.HasPrefix(line, "0,") {
+		if strings.HasPrefix(line, "0,") {
 			foundLeadingZero = true
 		}
 	}
@@ -148,6 +146,52 @@ func TestRunModelBlurCircleAndPointyRhabdom(t *testing.T) {
 	}
 }
 
+func TestDebugFlagOutput(t *testing.T) {
+	paramsNoDebug := Parameters{
+		SpeciesName:              "test_nodebug",
+		RhabdomLength:            100,
+		RhabdomWidth:             20,
+		EyeDiameter:              1000,
+		FacetWidth:               20,
+		ApertureDiameter:         500,
+		CytoplasmRefractiveIndex: 1.34,
+		RhabdomRefractiveIndex:   1.37,
+		BlurCircleExtent:         1,
+		ProximalRhabdomAngle:     0,
+	}
+	modelNoDebug := NewModel(paramsNoDebug)
+	modelNoDebug.DebugMode = false
+	modelNoDebug.runModel()
+
+	defer os.Remove("test_nodebug_pathlengths.csv")
+	if _, err := os.Stat("test_nodebug_debug.csv"); !os.IsNotExist(err) {
+		os.Remove("test_nodebug_debug.csv")
+		t.Errorf("Expected test_nodebug_debug.csv to NOT exist when DebugMode is false")
+	}
+
+	paramsDebug := Parameters{
+		SpeciesName:              "test_debug",
+		RhabdomLength:            100,
+		RhabdomWidth:             20,
+		EyeDiameter:              1000,
+		FacetWidth:               20,
+		ApertureDiameter:         500,
+		CytoplasmRefractiveIndex: 1.34,
+		RhabdomRefractiveIndex:   1.37,
+		BlurCircleExtent:         1,
+		ProximalRhabdomAngle:     0,
+	}
+	modelDebug := NewModel(paramsDebug)
+	modelDebug.DebugMode = true
+	modelDebug.runModel()
+
+	defer os.Remove("test_debug_pathlengths.csv")
+	defer os.Remove("test_debug_debug.csv")
+	if _, err := os.Stat("test_debug_debug.csv"); os.IsNotExist(err) {
+		t.Errorf("Expected test_debug_debug.csv to exist when DebugMode is true")
+	}
+}
+
 func TestCalculateRessensFullMatrix(t *testing.T) {
 	params := Parameters{
 		SpeciesName:              "test_matrix",
@@ -167,7 +211,6 @@ func TestCalculateRessensFullMatrix(t *testing.T) {
 	model.calculateRessens()
 
 	defer os.Remove("test_matrix_pathlengths.csv")
-	defer os.Remove("test_matrix_debug.csv")
 	defer os.Remove("test_matrix_summary_res.csv")
 	defer os.Remove("test_matrix_summary_sen.csv")
 

--- a/pathlength.go
+++ b/pathlength.go
@@ -16,6 +16,7 @@ const version = "0.6.0"
 func main() {
 	// --- Command Line Argument Parsing ---
 	paramFile := flag.String("f", "", "Path to a parameter file (CSV format). (Required)")
+	debugFlag := flag.Bool("d", false, "Generate debug CSV output file.")
 	showCitation := flag.Bool("c", false, "Show the program citation.")
 	showHelp := flag.Bool("h", false, "Show this help message.")
 	showLicense := flag.Bool("l", false, "Show the program license.")
@@ -50,7 +51,7 @@ Advances in Marine Biology: The Ecology and Biology of Nephrops norvegicus. Oxfo
 	}
 
 	if *showHelp {
-		fmt.Printf("Usage: %s -f filename [-h] [-v]\n", filepath.Base(os.Args[0]))
+		fmt.Printf("Usage: %s -f filename [-c] [-d] [-h] [-l] [-v]\n", filepath.Base(os.Args[0]))
 		flag.PrintDefaults()
 		os.Exit(0)
 	}
@@ -63,7 +64,7 @@ Advances in Marine Biology: The Ecology and Biology of Nephrops norvegicus. Oxfo
 	// --- Initialisation ---
 	// Exit if no parameter file is provided.
 	if *paramFile == "" {
-		fmt.Printf("Usage: %s -f filename [-h] [-v]\n", filepath.Base(os.Args[0]))
+		fmt.Printf("Usage: %s -f filename [-c] [-d] [-h] [-l] [-v]\n", filepath.Base(os.Args[0]))
 		flag.PrintDefaults()
 		log.Fatal("Error: No parameter file supplied. Use the -f flag to specify a file.")
 	}
@@ -77,6 +78,7 @@ Advances in Marine Biology: The Ecology and Biology of Nephrops norvegicus. Oxfo
 	// --- Loop over each parameter set and run the model ---
 	for _, params := range paramsList {
 		model := NewModel(params)
+		model.DebugMode = *debugFlag
 
 		fmt.Printf("--- Running simulation for %s ---\n", model.Params.SpeciesName)
 


### PR DESCRIPTION
## Summary of Changes

This PR adds a `-d` CLI flag for optional debug file generation and eliminates the legacy `998` sentinel from the pathlengths CSV format:

1. **Optional Debug Output (`-d` flag):**
   - Added `-d` flag to `pathlength.go` (default `false`).
   - Debug output (`{species}_debug.csv`) is only generated when `-d` is passed.
   - Added `TestDebugFlagOutput` unit test in `model_test.go`.

2. **Standardized CSV Output (Removal of `998`):**
   - Removed appending `998` to the end of each facet row in `model.go`.
   - Updated `calculateRessens()` in `csv.go` to parse facet rows via pigment header count tracking instead of matching `998`.

3. **Documentation:**
   - Updated `README.md` and `AGENTS.md` to document the `-d` flag, usage outputs, and output file behavior.
