### PR TITLE
fix(model): prevent negative resolution values on non-monotonic light profiles

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -82,9 +82,17 @@ func (m *Model) calculateRessens() {
 			}
 			diff := xz - yy
 			hwp := xz - halfwayPoint
-			frac := hwp / (diff + 0.1) // prevent div by zero
+			var frac float64
+			if diff > 0 && hwp >= 0 {
+				frac = math.Min(1.0, math.Max(0.0, hwp/(diff+0.1)))
+			} else {
+				frac = 0.0
+			}
 			oab := frac * m.OmmatidialAngle
 			res := oab + opticAxis
+			if res < 0 {
+				res = 0.0
+			}
 
 			if cc == 0 && dd > 0 {
 				fmt.Fprintln(sensWriter, strings.Join(matrixSens, ","))

--- a/model_test.go
+++ b/model_test.go
@@ -241,3 +241,52 @@ func TestCalculateRessensFullMatrix(t *testing.T) {
 		}
 	}
 }
+
+func TestCalculateRessensNephropsWideBlurCircle(t *testing.T) {
+	params := Parameters{
+		SpeciesName:              "test_nephrops_bce18",
+		RhabdomLength:            180,
+		RhabdomWidth:             25,
+		EyeDiameter:              7800,
+		FacetWidth:               50,
+		ApertureDiameter:         3200,
+		CytoplasmRefractiveIndex: 1.34,
+		RhabdomRefractiveIndex:   1.37,
+		BlurCircleExtent:         18,
+		ProximalRhabdomAngle:     0,
+	}
+
+	model := NewModel(params)
+	model.runModel()
+	model.calculateRessens()
+
+	defer os.Remove("test_nephrops_bce18_pathlengths.csv")
+	defer os.Remove("test_nephrops_bce18_summary_res.csv")
+	defer os.Remove("test_nephrops_bce18_summary_sen.csv")
+
+	resBytes, err := os.ReadFile("test_nephrops_bce18_summary_res.csv")
+	if err != nil {
+		t.Fatalf("Failed to read resolution summary file: %v", err)
+	}
+
+	resLines := strings.Split(strings.TrimSpace(string(resBytes)), "\n")
+	if len(resLines) != 11 {
+		t.Fatalf("Expected 11 rows in summary resolution file, got %d", len(resLines))
+	}
+
+	for rowIdx, line := range resLines {
+		parts := strings.Split(line, ",")
+		if len(parts) != 11 {
+			t.Errorf("Row %d: expected 11 columns, got %d", rowIdx, len(parts))
+		}
+		for colIdx, valStr := range parts {
+			val, err := strconv.Atoi(strings.TrimSpace(valStr))
+			if err != nil {
+				t.Errorf("Row %d, Col %d: invalid integer value '%s'", rowIdx, colIdx, valStr)
+			}
+			if val <= 0 {
+				t.Errorf("Row %d, Col %d: expected positive resolution value, got %d", rowIdx, colIdx, val)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes an edge case in the resolution calculation routine (`calculateRessens` in `csv.go`) where simulations with wide blur circle extents (such as `nephropsfl` with `BlurCircleExtent = 18`) could produce negative visual acceptance angle values in the summary resolution CSV.

---

## Root Cause & Fix

1. **Non-Monotonic Light Catch Profile**: When shielding pigment is retracted ($P=0$) and blur circle extent is high ($18$), off-axis rays illuminate peripheral rhabdoms ($rhabdom_{10 \dots 16}$) more strongly than the central rhabdom ($rhabdom_0$), resulting in rising rather than falling edges ($xz < yy$, meaning $diff < 0$).
2. **Interpolation Guard**:
   - The linear interpolation fraction is now safely bounded:
     - When $diff > 0$ and $hwp \ge 0$, $frac = \min(1.0, \max(0.0, hwp / (diff + 0.1)))$.
     - When $diff \le 0$ (rising edge), $frac = 0.0$ to prevent negative angular subtraction from the optic axis.
   - Resolution $res$ is guaranteed to satisfy $res \ge 0.0$.
3. **Unit Test Added**: Added `TestCalculateRessensNephropsWideBlurCircle` to `model_test.go` ensuring all 121 cells across the 11×11 matrix are strictly positive.

---

## Verification

- [x] All pre-commit hooks (`go-fmt`, `go-vet`, `go-test`) pass cleanly.
- [x] Full test suite (`go test -v ./...`) passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution calculations for edge cases involving invalid or out-of-range optical-axis values.
  * Prevented negative resolution results from being produced.

* **Tests**
  * Added coverage for wide-blur Nephrops configurations.
  * Verified that generated resolution summaries contain valid positive values in the expected 11×11 format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->