### PR TITLE
fix(model): apply mathematically rigorous return path geometry and exact interpolation

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -84,7 +84,7 @@ func (m *Model) calculateRessens() {
 			hwp := xz - halfwayPoint
 			var frac float64
 			if diff > 0 {
-				frac = hwp / (diff + 0.1) // allow unbounded forward extrapolation
+				frac = hwp / diff
 			} else {
 				frac = 0.0 // prevent backward extrapolation
 			}

--- a/csv_test.go
+++ b/csv_test.go
@@ -137,7 +137,7 @@ func TestCalculateRessens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to read resolution file: %v", err)
 	}
-	expectedRes := "228"
+	expectedRes := "229"
 	if !strings.Contains(string(resContent), expectedRes) {
 		t.Errorf("Resolution file content is wrong. Got '%s', expected to contain '%s'", string(resContent), expectedRes)
 	}

--- a/model.go
+++ b/model.go
@@ -212,11 +212,7 @@ func (m *Model) runModel() {
 						} else {
 							x = rhabdomLength / math.Abs(math.Cos(boa*degToRadConv))
 						}
-						if x > m.OldRhabdomLength {
-							v = x
-						} else {
-							v = m.OldRhabdomLength
-						}
+						v = m.OldRhabdomLength / math.Abs(math.Cos(boa*degToRadConv))
 
 						if m.TapetalPigment == 0 || m.ShieldingPigment > 0 {
 							val = x * facetNum
@@ -233,12 +229,7 @@ func (m *Model) runModel() {
 						if z > x {
 							z = x
 						}
-						var v float64
-						if (x + z) > m.OldRhabdomLength {
-							v = x + z
-						} else {
-							v = m.OldRhabdomLength
-						}
+						v := m.OldRhabdomLength / math.Abs(math.Cos(boa*degToRadConv))
 						if m.TapetalPigment == 0 {
 							val = (x + z) * facetNum
 						} else {


### PR DESCRIPTION
## Summary
- Upgrades the model's optical ray-tracing logic to be mathematically exact.
- **Return Path Geometry:** Replaces the heuristic `max(downward_path, L)` with the exact geometric slant path `L / cos(angle)` for upward reflecting rays.
- **Resolution Interpolation:** Removes the artificial `+ 0.1` distortion parameter from the Half-Width at Half-Maximum (HWHM) denominator, replacing it with pure linear interpolation guarded by `diff > 0`.
