### PR TITLE
Fix: remove artificial cap on TIR pathlength

### DIFF
--- a/model.go
+++ b/model.go
@@ -226,9 +226,6 @@ func (m *Model) runModel() {
 						var val float64
 						x := m.RhabdomRadius / math.Abs(math.Sin(boa*degToRadConv))
 						z := (rhabdomLength - y) / math.Abs(math.Cos(boa*degToRadConv))
-						if z > x {
-							z = x
-						}
 						v := m.OldRhabdomLength / math.Abs(math.Cos(boa*degToRadConv))
 						if m.TapetalPigment == 0 {
 							val = (x + z) * facetNum


### PR DESCRIPTION
Fixes a mathematical anomaly in Case 2 (Reflection from edge) where the pathlength to the base (z) was arbitrarily capped at the distance to the wall (x). This artificially destroyed pathlength for rays undergoing Total Internal Reflection (TIR) if the base was further away than a single wall-bounce. The full downward zigzag pathlength is now correctly preserved.
