### PR TITLE
docs: update CLAUDE.md link and README.md matrix term

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,3 @@
 # CLAUDE.md
 
-See [AGENTS.md](file:///Users/gawbul/Documents/Code/pathlength/AGENTS.md) for instructions and guidance for working with this repository.
+See [AGENTS.md](./AGENTS.md) for instructions and guidance for working with this repository.

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ genus	= A prefix for the output filenames e.g. organism genus name (lowercase al
 The following output files are created:
 
 * `genus_pathlengths.csv` - Raw ray geometry for each facet and pigment combination
-* `genus_summary_res.csv` - Acceptance angle matrix
+* `genus_summary_res.csv` - Resolution (acceptance angle) matrix
 * `genus_summary_sen.csv` - Sensitivity matrix
 * `genus_debug.csv` - (Optional) Per-ray trace, enabled with `-d`
 


### PR DESCRIPTION
This PR addresses two documentation updates:
1. Fixes the `AGENTS.md` link in `CLAUDE.md` to be a relative link.
2. Updates the term "Acceptance angle matrix" to "Resolution (acceptance angle) matrix" in `README.md`.
